### PR TITLE
Updates so build won't break

### DIFF
--- a/Gulp/assetTasks.js
+++ b/Gulp/assetTasks.js
@@ -61,7 +61,7 @@ gulp.task('b_m:appCss', function() {
 
 gulp.task('b_m:styles', function() {
     return gulp
-        .src([config.temp + 'bowerStyles.css', config.temp + 'lessStyles.css', config.temp + 'sassStyles.css', config.temp + 'appCss.css'])
+        .src(config.temp + '*.css')
         .pipe(replace('../fonts/', 'fonts/'))
         .pipe(concat(currVersion + '.css'))
         .pipe(gulp.dest(config.build + 'assets'))
@@ -69,8 +69,10 @@ gulp.task('b_m:styles', function() {
 });
 
 gulp.task('b_c:styles', function() {
-    return gulp.src([config.build + 'assets/**/*.css', config.temp + '**/*' ], {read:false})
-        .pipe(vinylPaths(del));
+    return del([
+        config.build + 'assets/**/*.css',
+        config.temp + '**/*'
+    ]);
 });
 
 gulp.task('b_m:assets', function() {
@@ -90,14 +92,14 @@ gulp.task('b_m:fonts', function() {
 });
 
 gulp.task('b_c:assets', function() {
-    return gulp.src([
+    return del([
         config.build + 'assets/**/*',
         '!' + config.build + '**/*.css',
         '!' + config.build + '**/*.less',
         '!' + config.build + '**/*.scss',
         '!' + config.build + '**/*.sass',
-        '!' + config.build + 'assets/fonts/**/*'], {read:false})
-        .pipe(vinylPaths(del))
+        '!' + config.build + 'assets/fonts/**/*'
+    ]);
 });
 
 /*COMPILE*/

--- a/Gulp/generalTasks.js
+++ b/Gulp/generalTasks.js
@@ -34,9 +34,11 @@ gulp.task('build:inject', function() {
 
 
 gulp.task('masterClean', function() {
-    return gulp
-        .src([config.build, config.compile, config.temp])
-        .pipe(vinylPaths(del));
+    return del([
+        config.build,
+        config.compile,
+        config.temp
+    ]);
 });
 
 //Major Project Build Tasks

--- a/Gulp/scriptTasks.js
+++ b/Gulp/scriptTasks.js
@@ -26,9 +26,9 @@ gulp.task('b_m:js_bower', function() {
 });
 
 gulp.task('b_c:js_bower', function() {
-    return gulp
-        .src(config.build + 'vendor', {read:false})
-        .pipe(gulp.dest('dist'));
+    return del([
+        config.build + 'vendor'
+    ]);
 });
 
 gulp.task('b_m:js', function() {
@@ -43,9 +43,10 @@ gulp.task('b_m:js', function() {
 });
 
 gulp.task('b_c:js', function() {
-    return gulp
-        .src([config.build + 'src/**/*.js', '!' + config.build + 'src/**/templates-app.js'], {read:false})
-        .pipe(gulp.dest('dist'));
+    return del([
+        config.build + 'src/**/*.js',
+        '!' + config.build + 'src/**/templates-app.js'
+    ]);
 });
 
 gulp.task('b_m:templateCache', function() {
@@ -59,9 +60,9 @@ gulp.task('b_m:templateCache', function() {
 });
 
 gulp.task('b_c:templateCache', function() {
-    return gulp
-        .src(config.build + 'src/templates-app.js', {read:false})
-        .pipe(gulp.dest('dist'));
+    return del([
+        config.build + 'src/templates-app.js'
+    ]);
 });
 
 gulp.task('c_m:js', function() {
@@ -81,8 +82,9 @@ gulp.task('c_m:js', function() {
 });
 
 gulp.task('c_c:js', function(){
-    return gulp.src(config.compile + '**/*.js', {read:false})
-        .pipe(gulp.dest('dist'));
+    return del([
+        config.compile + '**/*.js'
+    ]);
 });
 
 


### PR DESCRIPTION
I made a mistake and copied the wrong line when replacing the gulp-clean task. Also a task will fail if it cannot find a path given explicitly, so it is best to use a glob for these (see the change to the b_m:styles task for an example)