### PR TITLE
OC-938 adding condensed tables to global for desktop

### DIFF
--- a/src/app/global.less
+++ b/src/app/global.less
@@ -132,11 +132,12 @@ colgroup {
 .table > tbody > tr {
   > td {
 	&.actions-cell {
-	  text-align:right;
+	  text-align:center;
 	  white-space: nowrap;
-	  @media(max-width:@screen-xs-max) {
-		text-align:center;
-	  }
+      @media(min-width:@screen-sm-min) {
+        text-align: right;
+        width: 1%;
+      }
 	}
   }
 }

--- a/src/app/global.less
+++ b/src/app/global.less
@@ -215,6 +215,17 @@ colgroup {
   }
 
   @media(min-width:@screen-sm-min) {
+    // Condensed tables on desktop
+    > thead,
+    > tbody,
+    > tfoot {
+      > tr {
+        > th,
+        > td {
+          padding: @table-condensed-cell-padding;
+        }
+      }
+    }
     &.table-bordered {
       border:1px solid @table-border-color;
       & > tbody > tr{


### PR DESCRIPTION
You cant extend inside of a media query but these styles are still tied to a single variable so i think we should be good